### PR TITLE
Close input streams in PluginClassLoader.

### DIFF
--- a/coreAPI/src/java/net/java/games/input/PluginClassLoader.java
+++ b/coreAPI/src/java/net/java/games/input/PluginClassLoader.java
@@ -124,12 +124,16 @@ class PluginClassLoader extends ClassLoader {
             throw new ClassNotFoundException(name);
         }
         FileInputStream fileInputStream = new FileInputStream(file);
-        assert file.length() <= Integer.MAX_VALUE;
-        int length = (int)file.length();
-        byte[] bytes = new byte[length];
-        int length2 = fileInputStream.read(bytes);
-        assert length == length2;
-        return bytes;
+        try {
+            assert file.length() <= Integer.MAX_VALUE;
+            int length = (int)file.length();
+            byte[] bytes = new byte[length];
+            int length2 = fileInputStream.read(bytes);
+            assert length == length2;
+            return bytes;
+        } finally {
+            fileInputStream.close();
+        }
     }
     
     /**
@@ -148,13 +152,17 @@ class PluginClassLoader extends ClassLoader {
             JarEntry jarentry = jarfile.getJarEntry(name + ".class");
             if (jarentry != null) {
                 InputStream jarInputStream = jarfile.getInputStream(jarentry);
-                assert jarentry.getSize() <= Integer.MAX_VALUE;
-                int length = (int)jarentry.getSize();
-                assert length >= 0;
-                byte[] bytes = new byte[length];
-                int length2 = jarInputStream.read(bytes);
-                assert length == length2;
-                return bytes;
+                try {
+                    assert jarentry.getSize() <= Integer.MAX_VALUE;
+                    int length = (int)jarentry.getSize();
+                    assert length >= 0;
+                    byte[] bytes = new byte[length];
+                    int length2 = jarInputStream.read(bytes);
+                    assert length == length2;
+                    return bytes;
+                } finally {
+                    jarInputStream.close();
+                }
             }
         }
         throw new FileNotFoundException(name);


### PR DESCRIPTION
This is an update to https://java.net/jira/browse/JINPUT-51 to ensure that input streams in PluginClassLoader are closed before they become garbage, to avoid leaving file descriptors open longer than necessary.
