### PR TITLE
Support controller hot-plugging

### DIFF
--- a/coreAPI/src/java/net/java/games/input/DefaultControllerEnvironment.java
+++ b/coreAPI/src/java/net/java/games/input/DefaultControllerEnvironment.java
@@ -38,20 +38,16 @@
  *****************************************************************************/
 package net.java.games.input;
 
+import net.java.games.util.plugins.Plugins;
+
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.lang.reflect.Method;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.Properties;
 import java.util.StringTokenizer;
 import java.util.logging.Logger;
-
-import net.java.games.util.plugins.*;
 
 /**
  * The default controller environment.
@@ -105,7 +101,7 @@ class DefaultControllerEnvironment extends ControllerEnvironment {
     /**
      * List of all controllers in this environment
      */
-    private ArrayList controllers;
+    protected ArrayList controllers;
     
 	private Collection loadedPlugins = new ArrayList();
 

--- a/coreAPI/src/java/net/java/games/input/DisposableDevice.java
+++ b/coreAPI/src/java/net/java/games/input/DisposableDevice.java
@@ -1,0 +1,10 @@
+package net.java.games.input;
+
+import java.io.IOException;
+
+/**
+ * @author Capitrium
+ */
+public interface DisposableDevice {
+    void close() throws IOException;
+}

--- a/plugins/OSX/src/java/net/java/games/input/OSXEnvironmentPlugin.java
+++ b/plugins/OSX/src/java/net/java/games/input/OSXEnvironmentPlugin.java
@@ -38,17 +38,16 @@
 *****************************************************************************/
 package net.java.games.input;
 
+import net.java.games.util.plugins.Plugin;
+
 import java.io.File;
 import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.StringTokenizer;
-
-import net.java.games.util.plugins.Plugin;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.StringTokenizer;
 
 /** OSX HIDManager implementation
 * @author elias
@@ -71,11 +70,16 @@ public final class OSXEnvironmentPlugin extends ControllerEnvironment implements
 				new PrivilegedAction() {
 					public final Object run() {
 					    try {
-    						String lib_path = System.getProperty("net.java.games.input.librarypath");
-    						if (lib_path != null)
-    							System.load(lib_path + File.separator + System.mapLibraryName(lib_name));
-    						else
+							String lib_path = System.getProperty("net.java.games.input.librarypath");
+    						if (lib_path != null) {
+    							if (lib_path.indexOf(lib_name) != -1) {
+									System.load(lib_path);
+								} else {
+    								System.load(lib_path + File.separator + System.mapLibraryName(lib_name));
+								}
+							} else {
     							System.loadLibrary(lib_name);
+							}
 					    } catch (UnsatisfiedLinkError e) {
 					        e.printStackTrace();
 					        supported = false;

--- a/plugins/OSX/src/java/net/java/games/input/OSXHIDDevice.java
+++ b/plugins/OSX/src/java/net/java/games/input/OSXHIDDevice.java
@@ -50,7 +50,7 @@ import java.util.logging.Logger;
 * @author gregorypierce
 * @version 1.0
 */
-final class OSXHIDDevice {
+final class OSXHIDDevice implements DisposableDevice {
 	private final static Logger log = Logger.getLogger(OSXHIDDevice.class.getName());
 	private final static int AXIS_DEFAULT_MIN_VALUE = 0;
 	private final static int AXIS_DEFAULT_MAX_VALUE = 64*1024;
@@ -308,7 +308,7 @@ final class OSXHIDDevice {
 	}
 	private final static native void nOpen(long device_interface_address) throws IOException;
 
-	private final void close() throws IOException {
+	public synchronized final void close() throws IOException {
 		nClose(device_interface_address);
 	}
 	private final static native void nClose(long device_interface_address) throws IOException;

--- a/plugins/linux/src/java/net/java/games/input/LinuxDevice.java
+++ b/plugins/linux/src/java/net/java/games/input/LinuxDevice.java
@@ -25,15 +25,8 @@
  */
 package net.java.games.input;
 
-import java.io.IOException;
-import java.util.Map;
-import java.util.HashMap;
-import java.util.List;
-import java.util.ArrayList;
-
 /**
  * @author elias
  */
-interface LinuxDevice {
-	void close() throws IOException;
+interface LinuxDevice extends DisposableDevice {
 }

--- a/plugins/linux/src/java/net/java/games/input/LinuxEnvironmentPlugin.java
+++ b/plugins/linux/src/java/net/java/games/input/LinuxEnvironmentPlugin.java
@@ -63,10 +63,15 @@ public final class LinuxEnvironmentPlugin extends ControllerEnvironment implemen
 					public final Object run() {
 						String lib_path = System.getProperty("net.java.games.input.librarypath");
 						try {
-							if (lib_path != null)
-								System.load(lib_path + File.separator + System.mapLibraryName(lib_name));
-							else
+							if (lib_path != null) {
+								if (lib_path.indexOf(lib_name) != -1) {
+									System.load(lib_path);
+								} else {
+									System.load(lib_path + File.separator + System.mapLibraryName(lib_name));
+								}
+							} else {
 								System.loadLibrary(lib_name);
+							}
 						} catch (UnsatisfiedLinkError e) {
 							logln("Failed to load library: " + e.getMessage());
 							e.printStackTrace();

--- a/plugins/linux/src/java/net/java/games/input/LinuxJoystickDevice.java
+++ b/plugins/linux/src/java/net/java/games/input/LinuxJoystickDevice.java
@@ -26,10 +26,8 @@
 package net.java.games.input;
 
 import java.io.IOException;
-import java.util.Map;
 import java.util.HashMap;
-import java.util.List;
-import java.util.ArrayList;
+import java.util.Map;
 
 /**
  * @author elias

--- a/plugins/windows/src/java/net/java/games/input/DirectInputEnvironmentPlugin.java
+++ b/plugins/windows/src/java/net/java/games/input/DirectInputEnvironmentPlugin.java
@@ -38,14 +38,14 @@
  *****************************************************************************/
 package net.java.games.input;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import java.util.List;
-import java.util.ArrayList;
+import net.java.games.util.plugins.Plugin;
+
 import java.io.File;
 import java.io.IOException;
-
-import net.java.games.util.plugins.Plugin;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.ArrayList;
+import java.util.List;
 
 /** DirectInput implementation of controller environment
  * @author martak
@@ -68,11 +68,22 @@ public final class DirectInputEnvironmentPlugin extends ControllerEnvironment im
 				new PrivilegedAction() {
 					public final Object run() {
 					    try {
-    						String lib_path = System.getProperty("net.java.games.input.librarypath");
-    						if (lib_path != null)
-    							System.load(lib_path + File.separator + System.mapLibraryName(lib_name));
-    						else
-    							System.loadLibrary(lib_name);
+							String lib_path = System.getProperty("net.java.games.input.librarypath");
+							if (lib_path != null) {
+								String[] lib_path_parts = lib_path.split(";");
+								boolean found = false;
+								for (int i = 0; i < lib_path_parts.length; i++) {
+									if (lib_path_parts[i].indexOf(lib_name) != -1) {
+										System.load(lib_path);
+										found = true;
+										break;
+									}
+								}
+								if (!found)
+									System.load(lib_path + File.separator + System.mapLibraryName(lib_name));
+							} else {
+								System.loadLibrary(lib_name);
+							}
 					    } catch (UnsatisfiedLinkError e) {
 					        e.printStackTrace();
 					        supported = false;

--- a/plugins/windows/src/java/net/java/games/input/IDirectInputDevice.java
+++ b/plugins/windows/src/java/net/java/games/input/IDirectInputDevice.java
@@ -50,7 +50,7 @@ import java.util.Arrays;
  * @author elias
  * @version 1.0
  */
-final class IDirectInputDevice {
+final class IDirectInputDevice implements DisposableDevice {
 	public final static int GUID_XAxis = 1;
 	public final static int GUID_YAxis = 2;
 	public final static int GUID_ZAxis = 3;
@@ -541,6 +541,10 @@ final class IDirectInputDevice {
 	}
 
 	protected void finalize() {
+		release();
+	}
+
+	public synchronized final void close() {
 		release();
 	}
 }

--- a/plugins/windows/src/java/net/java/games/input/RawInputEnvironmentPlugin.java
+++ b/plugins/windows/src/java/net/java/games/input/RawInputEnvironmentPlugin.java
@@ -38,14 +38,14 @@
  *****************************************************************************/
 package net.java.games.input;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import java.util.List;
-import java.util.ArrayList;
+import net.java.games.util.plugins.Plugin;
+
 import java.io.File;
 import java.io.IOException;
-
-import net.java.games.util.plugins.Plugin;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.ArrayList;
+import java.util.List;
 
 /** DirectInput implementation of controller environment
  * @author martak
@@ -67,16 +67,27 @@ public final class RawInputEnvironmentPlugin extends ControllerEnvironment imple
 		AccessController.doPrivileged(
 				new PrivilegedAction() {
 					public final Object run() {
-					    try {
-    						String lib_path = System.getProperty("net.java.games.input.librarypath");
-    						if (lib_path != null)
-    							System.load(lib_path + File.separator + System.mapLibraryName(lib_name));
-    						else
-    							System.loadLibrary(lib_name);
-					    } catch (UnsatisfiedLinkError e) {
-					        e.printStackTrace();
-					        supported = false;
-					    }
+						try {
+							String lib_path = System.getProperty("net.java.games.input.librarypath");
+							if (lib_path != null) {
+								String[] lib_path_parts = lib_path.split(";");
+								boolean found = false;
+								for (int i = 0; i < lib_path_parts.length; i++) {
+									if (lib_path_parts[i].indexOf(lib_name) != -1) {
+										System.load(lib_path);
+										found = true;
+										break;
+									}
+								}
+								if (!found)
+									System.load(lib_path + File.separator + System.mapLibraryName(lib_name));
+							} else {
+								System.loadLibrary(lib_name);
+							}
+						} catch (UnsatisfiedLinkError e) {
+							e.printStackTrace();
+							supported = false;
+						}
 						return null;
 					}
 				});

--- a/plugins/wintab/src/java/net/java/games/input/WinTabEnvironmentPlugin.java
+++ b/plugins/wintab/src/java/net/java/games/input/WinTabEnvironmentPlugin.java
@@ -48,11 +48,16 @@ public class WinTabEnvironmentPlugin extends ControllerEnvironment implements Pl
 				new PrivilegedAction() {
 					public final Object run() {
 					    try {
-    						String lib_path = System.getProperty("net.java.games.input.librarypath");
-    						if (lib_path != null)
-    							System.load(lib_path + File.separator + System.mapLibraryName(lib_name));
-    						else
-    							System.loadLibrary(lib_name);
+							String lib_path = System.getProperty("net.java.games.input.librarypath");
+							if (lib_path != null) {
+								if (lib_path.indexOf(lib_name) != -1) {
+									System.load(lib_path);
+								} else {
+									System.load(lib_path + File.separator + System.mapLibraryName(lib_name));
+								}
+							} else {
+								System.loadLibrary(lib_name);
+							}
 					    } catch (UnsatisfiedLinkError e) {
 					        e.printStackTrace();
 					        supported = false;


### PR DESCRIPTION
Exposes a `ControllerEnvironment.refreshDefaultEnvironment()` method, allowing users to detect when controllers are removed (via the return value from a `Controller`'s `poll()` method) or added (i.e. checking for new controllers on a timer while on a menu screen in some game).

Also updates how plugin natives are loaded, so that the `net.java.games.input.librarypath` value can also contain an absolute path to a library or a list of paths.