### PR TITLE
Integrating changes from Conzar repo.

### DIFF
--- a/coreAPI/src/main/java/net/java/games/input/AbstractController.java
+++ b/coreAPI/src/main/java/net/java/games/input/AbstractController.java
@@ -230,4 +230,15 @@ public abstract class AbstractController implements Controller {
 		}
 	} 
 	
+    /**
+     * Grabs/captures the input to intercept the the events from going to the system.
+     * @return the status of the grab function where true is on success and false otherwise.
+     */
+    public boolean grab(){ return false; }
+
+    /**
+     * Releases the input capture back to the system.
+     * @return the status of the release function where true is on success and false otherwise.
+     */
+    public boolean ungrab(){ return false;}
 } // class AbstractController

--- a/plugins/linux/src/main/java/net/java/games/input/LinuxEventDevice.java
+++ b/plugins/linux/src/main/java/net/java/games/input/LinuxEventDevice.java
@@ -360,6 +360,35 @@ final class LinuxEventDevice implements LinuxDevice {
 			throw new IOException("Device is closed");
 	}
 
+    private final static native int nGrab(long fd, int grab) throws IOException;
+
+    /** 
+     * Grabs the device so that no other programs can read from the device.
+     */
+    public synchronized final boolean grab(){
+        try{
+            if(nGrab(fd,1) == 0){ 
+                return false;
+            }   
+        }catch(IOException e){ 
+            return false;
+        }   
+        return true;
+    }   
+    /** 
+     * Release the event so other programs can get events.
+     */
+    public synchronized final boolean ungrab(){
+        try{
+            if(nGrab(fd,0) == 0){ 
+                return false;
+            }   
+        }catch(IOException e){ 
+            return false;
+        }   
+        return true;
+    }   
+
 	@SuppressWarnings("deprecation")
 	protected void finalize() throws IOException {
 		close();

--- a/plugins/linux/src/main/java/net/java/games/input/LinuxKeyboard.java
+++ b/plugins/linux/src/main/java/net/java/games/input/LinuxKeyboard.java
@@ -65,4 +65,14 @@ final class LinuxKeyboard extends Keyboard {
 	public final void pollDevice() throws IOException {
 		device.pollKeyStates();
 	}
+
+    /**
+     * @Override
+     */
+    public boolean grab(){ return device.grab(); }
+
+    /**
+     * @Override
+     */
+    public boolean ungrab(){ return device.ungrab(); }
 }

--- a/plugins/linux/src/main/java/net/java/games/input/LinuxMouse.java
+++ b/plugins/linux/src/main/java/net/java/games/input/LinuxMouse.java
@@ -65,4 +65,14 @@ final class LinuxMouse extends Mouse {
 	protected final boolean getNextDeviceEvent(Event event) throws IOException {
 		return LinuxControllers.getNextDeviceEvent(event, device);
 	}
+
+    /**
+     * @Override
+     */
+    public boolean grab(){ return device.grab(); }
+
+    /**
+     * @Override
+     */
+    public boolean ungrab(){ return device.ungrab(); }
 }

--- a/plugins/linux/src/main/native/net_java_games_input_LinuxEventDevice.c
+++ b/plugins/linux/src/main/native/net_java_games_input_LinuxEventDevice.c
@@ -241,3 +241,14 @@ JNIEXPORT void JNICALL Java_net_java_games_input_LinuxEventDevice_nEraseEffect(J
 	if (ioctl(fd, EVIOCRMFF, &ff_id_int) == -1)
 		throwIOException(env, "Failed to erase effect (%d)\n", errno);
 }
+
+JNIEXPORT jint JNICALL Java_net_java_games_input_LinuxEventDevice_nGrab(JNIEnv *env, jclass unused, jlong fd_address, jint do_grab) {
+        int fd = (int)fd_address;
+        int grab = (int)do_grab;
+        if (ioctl(fd,EVIOCGRAB,grab) == -1){
+                throwIOException(env, "Failed to grab device (%d)\n", errno);
+            return -1; 
+    }   
+        return 1;
+}
+


### PR DESCRIPTION
Here are the changes for adding 'grab' and 'ungrab'.  This enables a device to NOT pass through the input to the operating system.  This allows programs like [KeyboardingMaster](https://bitbucket.org/conzar/keyboarding-master) to change the output to the operating system.

I have not added the 'rescanControllers' method as I am unsure that is required.  rescanControllers allowed for connecting and disconnecting devices while the program was still running.  Older versions of jinput could not detect changes in connectivity.  Is this still the case?  If so, I can create a separate PR for that.

Reference: https://github.com/jinput/jinput/issues/7