### PR TITLE
Setup Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+
+  - package-ecosystem: "maven"
+    directory: "/applet"
+    schedule:
+      interval: "monthly"
+
+  - package-ecosystem: "maven"
+    directory: "/coreAPI"
+    schedule:
+      interval: "monthly"
+
+  - package-ecosystem: "maven"
+    directory: "/examples"
+    schedule:
+      interval: "monthly"
+
+  - package-ecosystem: "maven"
+    directory: "/plugins"
+    schedule:
+      interval: "monthly"
+
+  - package-ecosystem: "maven"
+    directory: "/tests"
+    schedule:
+      interval: "monthly"
+
+  - package-ecosystem: "maven"
+    directory: "/uberjar"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
As it can be diffiicult to keep up with dependency/plugin updates, I have added support for Dependabot. It will automatically scan for potential updates on the first day of each month, and will raise a PR for each one found.

If this PR is merged, you will likely need to [enable Dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-alerts/configuring-dependabot-alerts#enabling-or-disabling-dependabot-alerts-for-a-repository) for the repository.

I ran a quick test on my fork and there will initially be at least 35 recommended updates. Many of them are minor/patch updates and can likely be accepted without causing issues. If you need help reviewing them, feel free to @ me 👍