### PR TITLE
Setup GitHub Action - Maven

### DIFF
--- a/.github/maven.yml
+++ b/.github/maven.yml
@@ -1,0 +1,28 @@
+name: Java CI with Maven
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: 8
+          java-package: jdk
+          architecture: x64
+
+      - name: Cache Maven Packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: Build with Maven
+        run: mvn --batch-mode --update-snapshots --file pom.xml --projects applet,coreAPI,plugins,uberjar,tests,examples --also-make clean install


### PR DESCRIPTION
Added a GitHub Action to run `mvn verify` on the `applet`, `coreAPI`, `plugins`, and `tests` projects.

I wasn't able to get the entire project to compile, due to build errors with the `uberjar` project, but having some of the projects covered by automated builds (and possibly tests in the future) may be beneficial. Especially to hint at whether new PRs may cause issues.