### PR TITLE
Fix 'Dead Threads' Issue (progress towards controller hot swap)

### DIFF
--- a/coreAPI/src/main/java/net/java/games/input/DefaultControllerEnvironment.java
+++ b/coreAPI/src/main/java/net/java/games/input/DefaultControllerEnvironment.java
@@ -40,6 +40,7 @@ import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 import java.util.StringTokenizer;
 import java.util.logging.Logger;
 
@@ -84,9 +85,11 @@ class DefaultControllerEnvironment extends ControllerEnvironment {
     /**
      * List of all controllers in this environment
      */
-    private ArrayList<Controller> controllers;
-    
+    protected ArrayList<Controller> controllers;
+
 	private Collection<String> loadedPluginNames = new ArrayList<>();
+
+	private final List<ControllerEnvironment> loadedPlugins = new ArrayList<>();
 
     /**
      * Public no-arg constructor.
@@ -135,6 +138,7 @@ class DefaultControllerEnvironment extends ControllerEnvironment {
 						if(ce.isSupported()) {
 							addControllers(ce.getControllers());
 							loadedPluginNames.add(ce.getClass().getName());
+                            this.loadedPlugins.add(ce);
 						} else {
 							log(ceClass.getName() + " is not supported");
 						}
@@ -153,14 +157,23 @@ class DefaultControllerEnvironment extends ControllerEnvironment {
         }
         return ret;
     }
-    
-    /* This is jeff's new plugin code using Jeff's Plugin manager */
+
+	@Override
+	public void release() {
+        this.loadedPlugins.forEach(it -> it.release());
+
+        this.controllers = null;
+        this.controllerListeners.clear();
+		return;
+	}
+
+	/* This is jeff's new plugin code using Jeff's Plugin manager */
     private Void scanControllers() {
         String pluginPathName = getPrivilegedProperty("jinput.controllerPluginPath");
         if(pluginPathName == null) {
             pluginPathName = "controller";
         }
-        
+
         scanControllersAt(getPrivilegedProperty("java.home") +
             File.separator + "lib"+File.separator + pluginPathName);
         scanControllersAt(getPrivilegedProperty("user.dir")+

--- a/coreAPI/src/main/java/net/java/games/input/DisposableDevice.java
+++ b/coreAPI/src/main/java/net/java/games/input/DisposableDevice.java
@@ -1,0 +1,10 @@
+package net.java.games.input;
+
+import java.io.IOException;
+
+/**
+ * @author Capitrium
+ */
+public interface DisposableDevice {
+    void close() throws IOException;
+}

--- a/plugins/awt/src/main/java/net/java/games/input/AWTEnvironmentPlugin.java
+++ b/plugins/awt/src/main/java/net/java/games/input/AWTEnvironmentPlugin.java
@@ -45,6 +45,12 @@ public class AWTEnvironmentPlugin extends ControllerEnvironment implements Plugi
         return controllers;
     }
 
+	@Override
+	public void release() {
+		// Not yet implemented
+		return;
+	}
+
 	public boolean isSupported() {
 		return true;
 	}

--- a/plugins/windows/src/main/java/net/java/games/input/DirectAndRawInputEnvironmentPlugin.java
+++ b/plugins/windows/src/main/java/net/java/games/input/DirectAndRawInputEnvironmentPlugin.java
@@ -84,6 +84,12 @@ public class DirectAndRawInputEnvironmentPlugin extends ControllerEnvironment {
 		return controllers;
 	}
 
+	@Override
+	public void release() {
+        this.rawPlugin.release();
+        this.dinputPlugin.release();
+	}
+
 	/**
 	 * @see net.java.games.input.ControllerEnvironment#isSupported()
 	 */

--- a/plugins/windows/src/main/java/net/java/games/input/DirectInputEnvironmentPlugin.java
+++ b/plugins/windows/src/main/java/net/java/games/input/DirectInputEnvironmentPlugin.java
@@ -138,6 +138,12 @@ public final class DirectInputEnvironmentPlugin extends ControllerEnvironment im
 		return controllers;
 	}
 
+	@Override
+	public void release() {
+		// Not yet implemented!
+		return;
+	}
+
 	private final Component[] createComponents(IDirectInputDevice device, boolean map_mouse_buttons) {
 		List<DIDeviceObject> device_objects = device.getObjects();
 		List<DIComponent> controller_components = new ArrayList<>();

--- a/plugins/windows/src/main/java/net/java/games/input/IDirectInputDevice.java
+++ b/plugins/windows/src/main/java/net/java/games/input/IDirectInputDevice.java
@@ -44,7 +44,7 @@ import java.util.Arrays;
  * @author elias
  * @version 1.0
  */
-final class IDirectInputDevice {
+final class IDirectInputDevice implements DisposableDevice {
 	public final static int GUID_XAxis = 1;
 	public final static int GUID_YAxis = 2;
 	public final static int GUID_ZAxis = 3;
@@ -537,5 +537,10 @@ final class IDirectInputDevice {
     @SuppressWarnings("deprecation")
 	protected void finalize() {
 		release();
+	}
+
+	@Override
+	public void close() throws IOException {
+        this.release();
 	}
 }

--- a/plugins/windows/src/main/java/net/java/games/input/RawInputEnvironmentPlugin.java
+++ b/plugins/windows/src/main/java/net/java/games/input/RawInputEnvironmentPlugin.java
@@ -55,6 +55,7 @@ import net.java.games.util.plugins.Plugin;
 public final class RawInputEnvironmentPlugin extends ControllerEnvironment implements Plugin {
 	
 	private static boolean supported = false;
+	private RawInputEventQueue queue;
 
 	/**
 	 * Static utility method for loading native libraries.
@@ -104,7 +105,6 @@ public final class RawInputEnvironmentPlugin extends ControllerEnvironment imple
 
 	/** Creates new DirectInputEnvironment */
 	public RawInputEnvironmentPlugin() {
-		RawInputEventQueue queue;
 		Controller[] controllers = new Controller[]{};
 		if(isSupported()) {
 			try {
@@ -119,6 +119,11 @@ public final class RawInputEnvironmentPlugin extends ControllerEnvironment imple
 
 	public final Controller[] getControllers() {
 		return controllers;
+	}
+
+	@Override
+	public void release() {
+        this.queue.destroyAll();
 	}
 
 	private final static SetupAPIDevice lookupSetupAPIDevice(String device_name, List<SetupAPIDevice> setupapi_devices) {

--- a/plugins/windows/src/main/native/net_java_games_input_DummyWindow.c
+++ b/plugins/windows/src/main/native/net_java_games_input_DummyWindow.c
@@ -64,6 +64,14 @@ JNIEXPORT jlong JNICALL Java_net_java_games_input_DummyWindow_createWindow(JNIEn
 
 JNIEXPORT void JNICALL Java_net_java_games_input_DummyWindow_nDestroy(JNIEnv *env, jclass unused, jlong hwnd_address) {
 	HWND hwndDummy = (HWND)(INT_PTR)hwnd_address;
+	MSG msg;
+
+    // Makes sure that the window has no more messages before it gets killed
+	while (PeekMessage(&msg, hwndDummy, 0, 0, PM_REMOVE)) {
+	    TranslateMessage(&msg);
+	    DispatchMessage(&msg);
+	}
+
 	BOOL result = DestroyWindow(hwndDummy);
 	if (!result) {
 		throwIOException(env, "Failed to destroy window (%d)\n", GetLastError());

--- a/plugins/windows/src/main/native/raw/net_java_games_input_RawInputEventQueue.c
+++ b/plugins/windows/src/main/native/raw/net_java_games_input_RawInputEventQueue.c
@@ -113,6 +113,11 @@ JNIEXPORT void JNICALL Java_net_java_games_input_RawInputEventQueue_nRegisterDev
 		throwIOException(env, "Failed to register raw devices (%d)\n", GetLastError());
 }
 
+JNIEXPORT void JNICALL Java_net_java_games_input_RawInputEventQueue_nPostMessage(JNIEnv *env, jobject self, jlong hwnd_handle) {
+    HWND hwnd = (HWND)(INT_PTR)hwnd_handle;
+    PostMessage((HWND) hwnd, WM_USER, 0, 0);
+}
+
 JNIEXPORT void JNICALL Java_net_java_games_input_RawInputEventQueue_nPoll(JNIEnv *env, jobject self, jlong hwnd_handle) {
 	MSG msg;
 	HWND hwnd = (HWND)(INT_PTR)hwnd_handle;
@@ -131,7 +136,11 @@ JNIEXPORT void JNICALL Java_net_java_games_input_RawInputEventQueue_nPoll(JNIEnv
 	addKeyboardEvent_method = (*env)->GetMethodID(env, self_class, "addKeyboardEvent", "(JJIIIIJ)V");
 	if (addKeyboardEvent_method == NULL)
 		return;
-	if (GetMessage(&msg, hwnd, 0, 0) != 0) {
+	if (GetMessage(&msg, hwnd, 0, 0) != 0) { // Note: GetMessage is blocking!
+	    if (msg.message == WM_USER) {
+	        // Dummy message used to break GetMessage, just return
+	        return;
+	    }
 		if (msg.message != WM_INPUT) {
 			DefWindowProc(hwnd, msg.message, msg.wParam, msg.lParam);
 			return; // ignore it

--- a/plugins/wintab/src/main/java/net/java/games/input/WinTabEnvironmentPlugin.java
+++ b/plugins/wintab/src/main/java/net/java/games/input/WinTabEnvironmentPlugin.java
@@ -120,6 +120,12 @@ public class WinTabEnvironmentPlugin extends ControllerEnvironment implements Pl
 		return controllers;
 	}
 
+	@Override
+	public void release() {
+		// Not yet implemented!
+		return;
+	}
+
 	private final class ShutdownHook extends Thread {
 		public final void run() {
 			/* Release the devices to kill off active force feedback effects */


### PR DESCRIPTION
### Overview
This commit addresses the 'dead threads' issue by introducing a solution involving the use of PostMessage to break GetMessage in the RawInputEventQueue. Additionally, it attempts to handle the cleanup of hidden windows spawned for input capture.

### Context
This solution was discussed [here](https://github.com/Valkryst/VController/issues/6)

### Things to note
* This PR represents an essential step towards implementing the controller hot swap feature. However, it's important to note that there is an outstanding issue: the hidden windows created for input capture may not disappear as expected after the environment is reset causing a resource leak. For more details on this issue, please refer to the discussion linked above.
* This applies only to Windows
* I've borrowed parts of this [PR](https://github.com/jinput/jinput/pull/11)