### PR TITLE
Incorporate VController

### DIFF
--- a/coreAPI/src/main/java/net/java/games/input/ControllerEnvironment.java
+++ b/coreAPI/src/main/java/net/java/games/input/ControllerEnvironment.java
@@ -79,13 +79,8 @@ public abstract class ControllerEnvironment {
     /**
      * The default controller environment
      */
-    private static ControllerEnvironment defaultEnvironment =
-        new DefaultControllerEnvironment();
-    
-    /**
-     * List of controller listeners
-     */
-    protected final ArrayList<ControllerListener> controllerListeners = new ArrayList<>();
+    private static ControllerEnvironment defaultEnvironment = new DefaultControllerEnvironment();
+
     
     /**
      * Protected constructor for subclassing.
@@ -105,51 +100,11 @@ public abstract class ControllerEnvironment {
     public abstract Controller[] getControllers();
     
     /**
-     * Adds a listener for controller state change events.
-     */
-    public void addControllerListener(ControllerListener l) {
-        assert l != null;
-        controllerListeners.add(l);
-    }
-    
-    /**
      * Returns the isSupported status of this environment.
      * What makes an environment supported or not is up to the
      * particular plugin, but may include OS or available hardware.
      */
     public abstract boolean isSupported();
-    
-    /**
-     * Removes a listener for controller state change events.
-     */
-    public void removeControllerListener(ControllerListener l) {
-        assert l != null;
-        controllerListeners.remove(l);
-    }
-    
-    /**
-     * Creates and sends an event to the controller listeners that a controller
-     * has been added.
-     */
-    protected void fireControllerAdded(Controller c) {
-        ControllerEvent ev = new ControllerEvent(c);
-        Iterator<ControllerListener> it = controllerListeners.iterator();
-        while (it.hasNext()) {
-            it.next().controllerAdded(ev);
-        }
-    }
-    
-    /**
-     * Creates and sends an event to the controller listeners that a controller
-     * has been lost.
-     */
-    protected void fireControllerRemoved(Controller c) {
-        ControllerEvent ev = new ControllerEvent(c);
-        Iterator<ControllerListener> it = controllerListeners.iterator();
-        while (it.hasNext()) {
-            it.next().controllerRemoved(ev);
-        }
-    }
     
     /**
      * Returns the default environment for input controllers.

--- a/coreAPI/src/main/java/net/java/games/input/ControllerListener.java
+++ b/coreAPI/src/main/java/net/java/games/input/ControllerListener.java
@@ -1,55 +1,17 @@
-/*
- * %W% %E%
- *
- * Copyright 2002 Sun Microsystems, Inc. All rights reserved.
- * SUN PROPRIETARY/CONFIDENTIAL. Use is subject to license terms.
- */
-/*****************************************************************************
- * Copyright (c) 2003 Sun Microsystems, Inc.  All Rights Reserved.
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * - Redistribution of source code must retain the above copyright notice,
- *   this list of conditions and the following disclaimer.
- *
- * - Redistribution in binary form must reproduce the above copyright notice,
- *   this list of conditions and the following disclaimer in the documentation
- *   and/or other materails provided with the distribution.
- *
- * Neither the name Sun Microsystems, Inc. or the names of the contributors
- * may be used to endorse or promote products derived from this software
- * without specific prior written permission.
- *
- * This software is provided "AS IS," without a warranty of any kind.
- * ALL EXPRESS OR IMPLIED CONDITIONS, REPRESENTATIONS AND WARRANTIES, INCLUDING
- * ANY IMPLIED WARRANT OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE OR
- * NON-INFRINGEMEN, ARE HEREBY EXCLUDED.  SUN MICROSYSTEMS, INC. ("SUN") AND
- * ITS LICENSORS SHALL NOT BE LIABLE FOR ANY DAMAGES SUFFERED BY LICENSEE AS
- * A RESULT OF USING, MODIFYING OR DESTRIBUTING THIS SOFTWARE OR ITS 
- * DERIVATIVES.  IN NO EVENT WILL SUN OR ITS LICENSORS BE LIABLE FOR ANY LOST
- * REVENUE, PROFIT OR DATA, OR FOR DIRECT, INDIRECT, SPECIAL, CONSEQUENTIAL,
- * INCIDENTAL OR PUNITIVE DAMAGES.  HOWEVER CAUSED AND REGARDLESS OF THE THEORY
- * OF LIABILITY, ARISING OUT OF THE USE OF OUR INABILITY TO USE THIS SOFTWARE,
- * EVEN IF SUN HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
- *
- * You acknowledge that this software is not designed or intended for us in
- * the design, construction, operation or maintenance of any nuclear facility
- *
- *****************************************************************************/
 package net.java.games.input;
 
+import java.util.EventListener;
+
 /**
- * A listener for changes in the state of controllers
+ * The listener interface for receiving {@link Controller} {@link Event}s.
+ *
+ * @author Valkryst
  */
-public interface ControllerListener {
-
+public interface ControllerListener extends EventListener {
     /**
-     * Invoked when a controller is lost.
+     * Invoked when an {@link Event} occurs.
+     *
+     * @param event {@code Event} to be processed.
      */
-    public abstract void controllerRemoved(ControllerEvent ev);
-
-    /**
-     * Invoked when a controller has been added.
-     */
-    public abstract void controllerAdded(ControllerEvent ev);
-} // interface ControllerListener
+    void eventOccurred(final Event event);
+}

--- a/coreAPI/src/main/java/net/java/games/input/ControllerPoller.java
+++ b/coreAPI/src/main/java/net/java/games/input/ControllerPoller.java
@@ -1,0 +1,119 @@
+package net.java.games.input;
+
+import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Class used to poll a {@link Controller} and notify {@link ControllerListener}s when {@link Event}s occur.
+ *
+ * @author Valkryst
+ */
+public class ControllerPoller {
+    /** {@link Controller} to poll. */
+    private final Controller controller;
+
+    /** Name of the {@link Controller}. */
+    private final String controllerName;
+
+    /** {@link ControllerListener}s to notify when {@link Event}s occur. */
+    private final CopyOnWriteArrayList<ControllerListener> listeners = new CopyOnWriteArrayList<>();
+
+    /** {@link ScheduledExecutorService} used to poll the {@link Controller} and notify {@code listeners}. */
+    private ScheduledExecutorService executorService;
+
+    /**
+     * Constructs a new {@code ControllerPoller}.
+     *
+     * @param controller The {@link Controller} to poll.
+     */
+    public ControllerPoller(final Controller controller) {
+        Objects.requireNonNull(controller);
+        this.controller = controller;
+
+        controllerName = controller.getName();
+    }
+
+    /**
+     * <p>Starts polling the {@link Controller}.</p>
+     *
+     * <p>See {@link ScheduledExecutorService#scheduleAtFixedRate(Runnable, long, long, TimeUnit)} for caveats.</p>
+     *
+     * @param pollingRate The polling rate, in milliseconds.
+     * @throws IllegalStateException If the {@code ControllerPoller} is already running or if the polling rate is less than 16 millisecond.
+     */
+    public void start(final int pollingRate) {
+        if (pollingRate < 1) {
+            throw new IllegalArgumentException("The polling rate cannot be less than 1 millisecond.");
+        }
+
+        // todo Verify thread safety of this block and everything within.
+        synchronized (this) {
+            if (executorService != null) {
+                throw new IllegalStateException("ControllerPoller is already running for '" + controllerName + "'.");
+            }
+
+            executorService = Executors.newSingleThreadScheduledExecutor();
+            executorService.scheduleAtFixedRate(() -> {
+                if (!controller.poll()) {
+                    System.err.println("The controller is no-longer valid. Stopping ControllerPoller for '" + controllerName + "'.");
+                    this.stop();
+                }
+
+                final EventQueue eventQueue = controller.getEventQueue();
+                while (true) {
+                    final Event event = new Event();
+                    eventQueue.getNextEvent(event);
+
+                    if (event.getComponent() == null) {
+                        break;
+                    } else {
+                        for (final ControllerListener listener : listeners) {
+                            listener.eventOccurred(event);
+                        }
+                    }
+                }
+            }, 0, pollingRate, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    /**
+     * Stops polling the {@link Controller}.
+     *
+     * @throws IllegalStateException If the {@code ControllerPoller} is not running.
+     */
+    public void stop() {
+        synchronized (this) {
+            if (executorService == null) {
+                throw new IllegalStateException("ControllerPoller is not running for '" + controllerName + "'.");
+            }
+
+            executorService.shutdown();
+            executorService = null;
+        }
+    }
+
+    /**
+     * Adds a {@link ControllerListener} to {@code listeners}.
+     *
+     * @param listener Listener to add.
+     * @throws NullPointerException If {@code listener} is {@code null}.
+     */
+    public void addListener(final ControllerListener listener) {
+        Objects.requireNonNull(listener);
+        listeners.add(listener);
+    }
+
+    /**
+     * Removes a {@link ControllerListener} from {@code listeners}.
+     *
+     * @param listener Listener to remove.
+     * @throws NullPointerException If {@code listener} is {@code null}.
+     */
+    public void removeListener(final ControllerListener listener) {
+        Objects.requireNonNull(listener);
+        listeners.remove(listener);
+    }
+}

--- a/coreAPI/src/main/java/net/java/games/input/HotSwapListener.java
+++ b/coreAPI/src/main/java/net/java/games/input/HotSwapListener.java
@@ -1,0 +1,24 @@
+package net.java.games.input;
+
+import java.util.EventListener;
+
+/**
+ * The listener interface for receiving hotswap (i.e. when a controller is added or removed) events.
+ *
+ * @author Valkryst
+ */
+public interface HotSwapListener extends EventListener {
+    /**
+     * Invoked when a new {@link Controller} is added to the system.
+     *
+     * @param controller The new {@link Controller}.
+     */
+    void controllerAdded(final Controller controller);
+
+    /**
+     * Invoked when a {@link Controller} is removed from the system.
+     *
+     * @param controller The removed {@link Controller}.
+     */
+    void controllerRemoved(final Controller controller);
+}


### PR DESCRIPTION
This PR incorporates everything, except for [HotSwapPoller](https://github.com/Valkryst/VController/blob/master/src/main/java/com/valkryst/VController/HotSwapPoller.java), from my [VController](https://github.com/Valkryst/VController/tree/master) project.

When hot swapping is either properly supported or in a state where `HotSwapPoller` can be implemented without leaking resources, then we can add that to this project. For now, the `HotSwapListener` will exist with no purpose.

Though this could potentially be a breaking change, it looks like the original `ControllerListener` was never actually used. None of the related methods in `ControllerEnvironment` seemed to be used at all. Assuming this is correct, it seemed okay to make these changes.

Additionally, I did write a quick-and-dirty example on how to use `ControllerPoller` and `ControllerListener` in [this README](https://github.com/Valkryst/VController/tree/master). We could add it to JInput's README, a wiki page, or somewhere else as a way to make the library that much easier to understand and use.