### PR TITLE
Setup GitHub Actions for Windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,29 @@
+name: Java Windows CI
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 11
+          java-package: jdk
+          architecture: x64
+
+      - uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Build with Maven
+        run: mvn --batch-mode install --file pom.xml --projects applet,coreAPI,plugins/windows
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-natives
+          path: plugins/windows/target/*.jar


### PR DESCRIPTION
This PR introduces a new GitHub Actions workflow for Windows. The workflow is triggered on each push, and it automates the build process on a Windows environment. It also uploads the resulting JAR file as an artifact. Should enable us to easily test builds in the future. 