### PR TITLE
Fix little typo

### DIFF
--- a/examples/src/main/java/net/java/games/input/example/ReadFirstMouse.java
+++ b/examples/src/main/java/net/java/games/input/example/ReadFirstMouse.java
@@ -67,7 +67,7 @@ public class ReadFirstMouse {
 			System.out.println(buffer.toString());
 
 			/*
-			 * Sleep for 20 millis, this is just so the example doesn't thrash
+			 * Sleep for 20 millis, this is just so the example doesn't trash
 			 * the system.
 			 */
 			try {


### PR DESCRIPTION
There's an typo in the word 'thrash', which is pronnunced 'trash'.